### PR TITLE
Support wasm targets by stubbing the futex calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,12 @@ license = "MIT"
 rust-version = "1.84.0"
 
 [dependencies]
-atomic-wait = "1.1.0"
 crossbeam = "0.8.4"
 equator = "0.4.2"
 rayon = "1.10.0"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+atomic-wait = "1.1.0"
 
 [dev-dependencies]
 aligned-vec = "0.6.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,19 @@ mod atomic_wait_imp {
 	}
 }
 
-#[cfg(not(loom))]
+#[cfg(all(not(loom), target_family = "wasm"))]
+mod atomic_wait_imp {
+	use core::sync::atomic::AtomicU32;
+	// On wasm targets there is no blocking futex available (and blocking is
+	// forbidden on the browser main thread). `wait` is documented to allow
+	// spurious returns, so a no-op is a valid implementation: callers must
+	// recheck their condition in a loop. With rayon reporting a single
+	// thread on wasm, no workers are spawned and these paths are idle.
+	pub fn wake_all(_atomic: *const AtomicU32) {}
+	pub fn wait(_atomic: &AtomicU32, _value: u32) {}
+}
+
+#[cfg(all(not(loom), not(target_family = "wasm")))]
 mod atomic_wait_imp {
 	pub use atomic_wait::{wait, wake_all};
 }


### PR DESCRIPTION
spindle fails to compile for wasm targets because atomic-wait is an OS futex wrapper with no wasm backend. This also blocks faer, which pulls in spindle through its "rayon" feature.

This PR adds a no-op stub gated on target_family = "wasm", mirroring the existing loom stub, and makes the atomic-wait dependency non-wasm only.

A no-op wait is valid since spurious returns are allowed and callers recheck in a loop. On wasm rayon reports one thread, so no workers are spawned and the wait/wake paths are idle.

Verified: native tests pass unchanged, both wasm targets compile, and faer (gemm, SVD, eigen) runs correctly through this stub under wasmtime.