### PR TITLE
Remove unused crossbeam dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,28 +159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,15 +173,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -705,7 +674,6 @@ version = "0.2.6"
 dependencies = [
  "aligned-vec",
  "atomic-wait",
- "crossbeam",
  "diol",
  "equator 0.4.2",
  "loom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ rust-version = "1.84.0"
 
 [dependencies]
 atomic-wait = "1.1.0"
-crossbeam = "0.8.4"
 equator = "0.4.2"
 rayon = "1.10.0"
 


### PR DESCRIPTION
crossbeam is declared in Cargo.toml but never used anywhere in src or examples. Removing it drops the umbrella crate and its transitive dependencies from the build graph. rayon keeps its own crossbeam-deque subset, which is unaffected.

Verified: native tests pass, the loom cfg and the bench example still build.